### PR TITLE
Enhance battle logic and skill system

### DIFF
--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -1,9 +1,10 @@
 export const calcDamage = ({ target, attacker }) => {
-	let armorCalc = target.armor;
-	if (armorCalc > 50) {
-		armorCalc = 50;
-	}
-	return attacker.attack - armorCalc;
+        let armorCalc = target.armor;
+        if (armorCalc > 50) {
+                armorCalc = 50;
+        }
+        // Ensure damage cannot be negative
+        return Math.max(0, attacker.attack - armorCalc);
 };
 
 export const getRandomTarget = targetTeam => {
@@ -50,15 +51,13 @@ export const handleChargeGain = ({ attacker, times }) => {
 };
 
 export const checkWin = ({ playerTeam, enemyTeam, setGameState }) => {
-	const availablePlayers = playerTeam.filter(target => target.health > 0);
-	const availableEnemies = enemyTeam.filter(target => target.health > 0);
-	if (availableEnemies <= 0) {
-		setGameState('win');
-	} else {
-		if (availablePlayers <= 0) {
-			setGameState('loss');
-		}
-	}
+        const availablePlayers = playerTeam.filter(target => target.health > 0);
+        const availableEnemies = enemyTeam.filter(target => target.health > 0);
+        if (availableEnemies.length <= 0) {
+                setGameState('win');
+        } else if (availablePlayers.length <= 0) {
+                setGameState('loss');
+        }
 };
 
 export const battleLog = ({ attacker, target, damage, currentTurn, setAttackLog, attackLog }) => {

--- a/src/data/playerCharacters.js
+++ b/src/data/playerCharacters.js
@@ -15,25 +15,15 @@ const initialPlayerTeam = [
 		maxCharge: 100,
 		img: 'https://gbf.wiki/images/thumb/f/f9/Npc_m_3040081000_01.jpg/150px-Npc_m_3040081000_01.jpg',
 		skills: [
-			{
-				id: 1,
-				name: 'Fireball1',
-				description: 'Pew',
-				damage: 200,
-				manaCost: 50,
-				maxCooldown: 5,
-				cooldown: 0,
-				useSkill: function ({ character, playerTeam, enemyTeam, selectedTarget }) {
-					let target = null;
-					if (selectedTarget !== undefined && selectedTarget !== 0) {
-						target = enemyTeam.find(target => target.id === selectedTarget);
-						console.log('fireball has hit a selected target: ', target);
-					} else {
-						target = enemyTeam.find(target => target.id === 4 || target.id === 5 || target.id === 6);
-						console.log('fireball has hit the first available target: ', target.name);
-					}
-				},
-			},
+                        {
+                                id: 1,
+                                name: 'Fireball1',
+                                description: 'Pew',
+                                damage: 200,
+                                manaCost: 50,
+                                maxCooldown: 5,
+                                cooldown: 0,
+                        },
 			{
 				id: 2,
 				name: 'Heal1',


### PR DESCRIPTION
## Summary
- prevent negative damage and fix win-condition detection
- implement mana-based skills with damage, healing, and armor buffs
- disable skills when insufficient mana

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6894fee4c584832f923b51e7f921bd1b