### PR TITLE
Fix win check to compare team size correctly

### DIFF
--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -50,15 +50,13 @@ export const handleChargeGain = ({ attacker, times }) => {
 };
 
 export const checkWin = ({ playerTeam, enemyTeam, setGameState }) => {
-	const availablePlayers = playerTeam.filter(target => target.health > 0);
-	const availableEnemies = enemyTeam.filter(target => target.health > 0);
-	if (availableEnemies <= 0) {
-		setGameState('win');
-	} else {
-		if (availablePlayers <= 0) {
-			setGameState('loss');
-		}
-	}
+       const availablePlayers = playerTeam.filter(target => target.health > 0);
+       const availableEnemies = enemyTeam.filter(target => target.health > 0);
+       if (availableEnemies.length <= 0) {
+               setGameState('win');
+       } else if (availablePlayers.length <= 0) {
+               setGameState('loss');
+       }
 };
 
 export const battleLog = ({ attacker, target, damage, currentTurn, setAttackLog, attackLog }) => {


### PR DESCRIPTION
## Summary
- fix `checkWin` to check team array lengths to determine victory

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6894feccfad0832fb9b5561270d3081b