### PR TITLE
test: add checkWin tests

### DIFF
--- a/src/components/utils.test.js
+++ b/src/components/utils.test.js
@@ -1,0 +1,35 @@
+import { checkWin } from './utils';
+
+describe('checkWin', () => {
+  it("sets 'win' when all enemies have health <= 0", () => {
+    const setGameState = jest.fn();
+    const playerTeam = [
+      { id: 1, health: 10 },
+      { id: 2, health: 20 },
+    ];
+    const enemyTeam = [
+      { id: 3, health: 0 },
+      { id: 4, health: -5 },
+    ];
+
+    checkWin({ playerTeam, enemyTeam, setGameState });
+
+    expect(setGameState).toHaveBeenCalledWith('win');
+  });
+
+  it("sets 'loss' when all players have health <= 0", () => {
+    const setGameState = jest.fn();
+    const playerTeam = [
+      { id: 1, health: 0 },
+      { id: 2, health: 0 },
+    ];
+    const enemyTeam = [
+      { id: 3, health: 10 },
+      { id: 4, health: 5 },
+    ];
+
+    checkWin({ playerTeam, enemyTeam, setGameState });
+
+    expect(setGameState).toHaveBeenCalledWith('loss');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for checkWin ensuring setGameState is called when all players or enemies are defeated

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689501d74ba4832f9c877d2ea44a1275